### PR TITLE
Add GitHub profile stats card

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Also contribute to open-source from time to time, especially for Google's gemini
 
 ## 🚀 GitHub Dashboard
 
+![Aashir's GitHub Stats](https://github-readme-stats-eight-theta.vercel.app/api?username=Aaxhirrr&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&count_private=true)
+
 ![GitHub Streak](https://streak-stats.demolab.com?user=Aaxhirrr&theme=tokyonight&hide_border=true)
 
 <!-- ![Metrics](https://raw.githubusercontent.com/Aaxhirrr/Aaxhirrr/main/github-metrics.svg) -->

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Also contribute to open-source from time to time, especially for Google's gemini
 
 ## 🚀 GitHub Dashboard
 
-![Aashir's GitHub Stats](https://github-readme-stats-eight-theta.vercel.app/api?username=Aaxhirrr&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&count_private=true)
+[![Aashir's GitHub Stats](https://github-readme-stats-eight-theta.vercel.app/api?username=Aaxhirrr&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&count_private=true)](https://github.com/Aaxhirrr)
 
 ![GitHub Streak](https://streak-stats.demolab.com?user=Aaxhirrr&theme=tokyonight&hide_border=true)
 


### PR DESCRIPTION
## What changed
- adds a live GitHub statistics card to the profile dashboard
- displays grade, commits, pull requests, issues, stars, and contributed repositories
- matches the existing Tokyo Night theme
- links the card back to the GitHub profile

## Verification
- stats SVG endpoint returned HTTP 200
- rendered card reports an A++ grade and current profile totals
- `git diff --check` passes

This PR is intentionally left unmerged.