### PR TITLE
Show private-inclusive GitHub profile statistics

### DIFF
--- a/.github/workflows/private-stats.yml
+++ b/.github/workflows/private-stats.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out profile repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Generate authenticated stats card
         uses: stats-organization/github-readme-stats-action@e856fc8de9d7729b463c468911e232cfbdc3d55e # v2.0.2
         with:
           card: stats
-          options: "username=${{ github.repository_owner }}&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&role=OWNER,ORGANIZATION_MEMBER,COLLABORATOR&number_format=long&show=prs_merged,reviews&custom_title=Aashir%27s%20GitHub%20Stats"
+          options: "username=${{ github.repository_owner }}&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&role=OWNER,ORGANIZATION_MEMBER,COLLABORATOR&number_format=long&show=prs_merged&custom_title=Aashir%27s%20GitHub%20Stats"
           path: profile/stats.svg
           token: ${{ secrets.PROFILE_STATS_TOKEN }}
           core_version: 2.1.5

--- a/.github/workflows/private-stats.yml
+++ b/.github/workflows/private-stats.yml
@@ -10,6 +10,7 @@ on:
       - AASHIR/private-profile-stats
     paths:
       - .github/workflows/private-stats.yml
+      - scripts/normalize-profile-stats.mjs
 
 permissions:
   contents: write

--- a/.github/workflows/private-stats.yml
+++ b/.github/workflows/private-stats.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - AASHIR/private-profile-stats
     paths:
       - .github/workflows/private-stats.yml
       - scripts/normalize-profile-stats.mjs

--- a/.github/workflows/private-stats.yml
+++ b/.github/workflows/private-stats.yml
@@ -1,0 +1,51 @@
+name: Update private-inclusive GitHub stats
+
+on:
+  schedule:
+    - cron: "15 3 * * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - AASHIR/private-profile-stats
+    paths:
+      - .github/workflows/private-stats.yml
+
+permissions:
+  contents: write
+
+concurrency:
+  group: profile-stats-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out profile repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Generate authenticated stats card
+        uses: stats-organization/github-readme-stats-action@e856fc8de9d7729b463c468911e232cfbdc3d55e # v2.0.2
+        with:
+          card: stats
+          options: "username=${{ github.repository_owner }}&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&role=OWNER,ORGANIZATION_MEMBER,COLLABORATOR&number_format=long&show=prs_merged,reviews&custom_title=Aashir%27s%20GitHub%20Stats"
+          path: profile/stats.svg
+          token: ${{ secrets.PROFILE_STATS_TOKEN }}
+          core_version: 2.1.5
+          fail_on_error: true
+
+      - name: Verify totals and show every accessible repository
+        env:
+          PROFILE_STATS_TOKEN: ${{ secrets.PROFILE_STATS_TOKEN }}
+          PROFILE_STATS_USERNAME: ${{ github.repository_owner }}
+        run: node scripts/normalize-profile-stats.mjs
+
+      - name: Commit refreshed card
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add profile/stats.svg
+          git diff --cached --quiet && exit 0
+          git commit -m "Update private-inclusive stats [skip ci]"
+          git push

--- a/.github/workflows/private-stats.yml
+++ b/.github/workflows/private-stats.yml
@@ -29,7 +29,7 @@ jobs:
         uses: stats-organization/github-readme-stats-action@e856fc8de9d7729b463c468911e232cfbdc3d55e # v2.0.2
         with:
           card: stats
-          options: "username=${{ github.repository_owner }}&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&role=OWNER,ORGANIZATION_MEMBER,COLLABORATOR&number_format=long&show=prs_merged&custom_title=Aashir%27s%20GitHub%20Stats"
+          options: "username=${{ github.repository_owner }}&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&role=OWNER,ORGANIZATION_MEMBER,COLLABORATOR&number_format=long&show=prs_merged&disable_animations=true&custom_title=Aashir%27s%20GitHub%20Stats"
           path: profile/stats.svg
           token: ${{ secrets.PROFILE_STATS_TOKEN }}
           core_version: 2.1.5

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Also contribute to open-source from time to time, especially for Google's gemini
 
 ## 🚀 GitHub Dashboard
 
-[![Aashir's GitHub Stats](https://github-readme-stats-eight-theta.vercel.app/api?username=Aaxhirrr&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&count_private=true)](https://github.com/Aaxhirrr)
+[![Aashir's private-inclusive GitHub Stats](./profile/stats.svg)](https://github.com/Aaxhirrr)
 
 ![GitHub Streak](https://streak-stats.demolab.com?user=Aaxhirrr&theme=tokyonight&hide_border=true)
 

--- a/profile/stats.svg
+++ b/profile/stats.svg
@@ -9,7 +9,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">Aashir&#39;s GitHub Stats, Rank: B+</title>
-        <desc id="descId">Total Stars Earned: 16, Total Commits  : 4784, Total PRs: 390, Total PRs Merged: 322, Total Issues: 5, All Repositories: 7</desc>
+        <desc id="descId">Total Stars Earned: 16, Total Commits  : 4784, Total PRs: 390, Total PRs Merged: 322, Total Issues: 5, All Repositories: 67</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;

--- a/profile/stats.svg
+++ b/profile/stats.svg
@@ -1,15 +1,15 @@
 
       <svg
         width="467"
-        height="245"
-        viewBox="0 0 467 245"
+        height="220"
+        viewBox="0 0 467 220"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
         role="img"
         aria-labelledby="descId"
       >
         <title id="titleId">Aashir&#39;s GitHub Stats, Rank: B+</title>
-        <desc id="descId">Total Stars Earned: 16, Total Commits  : 4784, Total PRs: 390, Total PRs Merged: 322, Total PRs Reviewed: 0, Total Issues: 5, Contributed to (last year): 7</desc>
+        <desc id="descId">Total Stars Earned: 16, Total Commits  : 4784, Total PRs: 390, Total PRs Merged: 322, Total Issues: 5, All Repositories: 7</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
@@ -137,7 +137,7 @@
         >
           
     <g data-testid="rank-circle"
-          transform="translate(390.5, 72.5)">
+          transform="translate(390.5, 60)">
         <circle class="rank-circle-rim" cx="-10" cy="8" r="40" />
         <circle class="rank-circle" cx="-10" cy="8" r="40" />
         <g class="rank-text">
@@ -213,21 +213,6 @@
     <g class="stagger" style="animation-delay: 1050ms" transform="translate(25, 0)">
       
     <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
-      <path fill-rule="evenodd" d="M8 2c1.981 0 3.671.992 4.933 2.078 1.27 1.091 2.187 2.345 2.637 3.023a1.62 1.62 0 0 1 0 1.798c-.45.678-1.367 1.932-2.637 3.023C11.67 13.008 9.981 14 8 14c-1.981 0-3.671-.992-4.933-2.078C1.797 10.83.88 9.576.43 8.898a1.62 1.62 0 0 1 0-1.798c.45-.677 1.367-1.931 2.637-3.022C4.33 2.992 6.019 2 8 2ZM1.679 7.932a.12.12 0 0 0 0 .136c.411.622 1.241 1.75 2.366 2.717C5.176 11.758 6.527 12.5 8 12.5c1.473 0 2.825-.742 3.955-1.715 1.124-.967 1.954-2.096 2.366-2.717a.12.12 0 0 0 0-.136c-.412-.621-1.242-1.75-2.366-2.717C10.824 4.242 9.473 3.5 8 3.5c-1.473 0-2.825.742-3.955 1.715-1.124.967-1.954 2.096-2.366 2.717ZM8 10a2 2 0 1 1-.001-3.999A2 2 0 0 1 8 10Z"/>
-    </svg>
-  
-      <text class="stat  bold" x="25" y="12.5">Total PRs Reviewed:</text>
-      <text
-        class="stat  bold"
-        x="224.01"
-        y="12.5"
-        data-testid="reviews"
-      >0</text>
-    </g>
-  </g><g transform="translate(0, 125)">
-    <g class="stagger" style="animation-delay: 1200ms" transform="translate(25, 0)">
-      
-    <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
       <path fill-rule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm9 3a1 1 0 11-2 0 1 1 0 012 0zm-.25-6.25a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z"/>
     </svg>
   
@@ -239,14 +224,14 @@
         data-testid="issues"
       >5</text>
     </g>
-  </g><g transform="translate(0, 150)">
-    <g class="stagger" style="animation-delay: 1350ms" transform="translate(25, 0)">
+  </g><g transform="translate(0, 125)">
+    <g class="stagger" style="animation-delay: 1200ms" transform="translate(25, 0)">
       
     <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
       <path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"/>
     </svg>
   
-      <text class="stat  bold" x="25" y="12.5">Contributed to (last year):</text>
+      <text class="stat  bold" x="25" y="12.5">All Repositories:</text>
       <text
         class="stat  bold"
         x="224.01"

--- a/profile/stats.svg
+++ b/profile/stats.svg
@@ -1,5 +1,4 @@
-
-      <svg
+<svg
         width="467"
         height="220"
         viewBox="0 0 467 220"
@@ -9,7 +8,7 @@
         aria-labelledby="descId"
       >
         <title id="titleId">Aashir&#39;s GitHub Stats, Rank: B+</title>
-        <desc id="descId">Total Stars Earned: 16, Total Commits  : 4784, Total PRs: 390, Total PRs Merged: 322, Total Issues: 5, All Repositories: 67</desc>
+        <desc id="descId">Total Stars Earned: 16, Total Commits  : 4784, Total PRs: 391, Total PRs Merged: 322, Total Issues: 5, All Repositories: 67</desc>
         <style>
           .header {
             font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
@@ -20,7 +19,7 @@
             /* Selector detects Firefox */
             .header { font-size: 15.5px; }
           }
-          
+
     .stat {
       font: 600 14px 'Segoe UI', Ubuntu, "Helvetica Neue", Sans-Serif; fill: #38bdae;
     }
@@ -42,7 +41,7 @@
     .rank-percentile-text {
       font-size: 16px;
     }
-    
+
     .not_bold { font-weight: 400 }
     .bold { font-weight: 700 }
     .icon {
@@ -67,7 +66,7 @@
       transform: rotate(-90deg);
       animation: rankAnimation 1s forwards ease-in-out;
     }
-    
+
     @keyframes rankAnimation {
       from {
         stroke-dashoffset: 251.32741228718345;
@@ -76,10 +75,10 @@
         stroke-dashoffset: 113.17222826770345;
       }
     }
-  
-  
 
-          
+
+
+
       /* Animations */
       @keyframes scaleInAnimation {
         from {
@@ -97,11 +96,11 @@
           opacity: 1;
         }
       }
-    
-          
+
+
         </style>
 
-        
+
 
         <rect
           data-testid="card-bg"
@@ -115,7 +114,7 @@
           stroke-opacity="0"
         />
 
-        
+
       <g
         data-testid="card-title"
         transform="translate(25, 35)"
@@ -129,33 +128,33 @@
       >Aashir&#39;s GitHub Stats</text>
     </g>
       </g>
-    
+
 
         <g
           data-testid="main-card-body"
           transform="translate(0, 55)"
         >
-          
+
     <g data-testid="rank-circle"
           transform="translate(390.5, 60)">
         <circle class="rank-circle-rim" cx="-10" cy="8" r="40" />
         <circle class="rank-circle" cx="-10" cy="8" r="40" />
         <g class="rank-text">
-          
+
         <text x="-5" y="3" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="level-rank-icon">
           B+
         </text>
-      
+
         </g>
       </g>
     <svg x="0" y="0">
       <g transform="translate(0, 0)">
     <g class="stagger" style="animation-delay: 450ms" transform="translate(25, 0)">
-      
+
     <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
       <path fill-rule="evenodd" d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z"/>
     </svg>
-  
+
       <text class="stat  bold" x="25" y="12.5">Total Stars Earned:</text>
       <text
         class="stat  bold"
@@ -166,11 +165,11 @@
     </g>
   </g><g transform="translate(0, 25)">
     <g class="stagger" style="animation-delay: 600ms" transform="translate(25, 0)">
-      
+
     <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
       <path fill-rule="evenodd" d="M1.643 3.143L.427 1.927A.25.25 0 000 2.104V5.75c0 .138.112.25.25.25h3.646a.25.25 0 00.177-.427L2.715 4.215a6.5 6.5 0 11-1.18 4.458.75.75 0 10-1.493.154 8.001 8.001 0 101.6-5.684zM7.75 4a.75.75 0 01.75.75v2.992l2.028.812a.75.75 0 01-.557 1.392l-2.5-1A.75.75 0 017 8.25v-3.5A.75.75 0 017.75 4z"/>
     </svg>
-  
+
       <text class="stat  bold" x="25" y="12.5">Total Commits:</text>
       <text
         class="stat  bold"
@@ -181,26 +180,26 @@
     </g>
   </g><g transform="translate(0, 50)">
     <g class="stagger" style="animation-delay: 750ms" transform="translate(25, 0)">
-      
+
     <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
       <path fill-rule="evenodd" d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
     </svg>
-  
+
       <text class="stat  bold" x="25" y="12.5">Total PRs:</text>
       <text
         class="stat  bold"
         x="224.01"
         y="12.5"
         data-testid="prs"
-      >390</text>
+      >391</text>
     </g>
   </g><g transform="translate(0, 75)">
     <g class="stagger" style="animation-delay: 900ms" transform="translate(25, 0)">
-      
+
     <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
       <path fill-rule="evenodd" d="M5.45 5.154A4.25 4.25 0 0 0 9.25 7.5h1.378a2.251 2.251 0 1 1 0 1.5H9.25A5.734 5.734 0 0 1 5 7.123v3.505a2.25 2.25 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.95-.218ZM4.25 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm8.5-4.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 3.25a.75.75 0 1 0 0 .005V3.25Z" />
     </svg>
-  
+
       <text class="stat  bold" x="25" y="12.5">Total PRs Merged:</text>
       <text
         class="stat  bold"
@@ -211,11 +210,11 @@
     </g>
   </g><g transform="translate(0, 100)">
     <g class="stagger" style="animation-delay: 1050ms" transform="translate(25, 0)">
-      
+
     <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
       <path fill-rule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm9 3a1 1 0 11-2 0 1 1 0 012 0zm-.25-6.25a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z"/>
     </svg>
-  
+
       <text class="stat  bold" x="25" y="12.5">Total Issues:</text>
       <text
         class="stat  bold"
@@ -226,11 +225,11 @@
     </g>
   </g><g transform="translate(0, 125)">
     <g class="stagger" style="animation-delay: 1200ms" transform="translate(25, 0)">
-      
+
     <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
       <path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"/>
     </svg>
-  
+
       <text class="stat  bold" x="25" y="12.5">All Repositories:</text>
       <text
         class="stat  bold"
@@ -241,7 +240,6 @@
     </g>
   </g>
     </svg>
-  
+
         </g>
       </svg>
-    

--- a/profile/stats.svg
+++ b/profile/stats.svg
@@ -1,0 +1,262 @@
+
+      <svg
+        width="467"
+        height="245"
+        viewBox="0 0 467 245"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        role="img"
+        aria-labelledby="descId"
+      >
+        <title id="titleId">Aashir&#39;s GitHub Stats, Rank: B+</title>
+        <desc id="descId">Total Stars Earned: 16, Total Commits  : 4784, Total PRs: 390, Total PRs Merged: 322, Total PRs Reviewed: 0, Total Issues: 5, Contributed to (last year): 7</desc>
+        <style>
+          .header {
+            font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
+            fill: #70a5fd;
+            animation: fadeInAnimation 0.8s ease-in-out forwards;
+          }
+          @supports(-moz-appearance: auto) {
+            /* Selector detects Firefox */
+            .header { font-size: 15.5px; }
+          }
+          
+    .stat {
+      font: 600 14px 'Segoe UI', Ubuntu, "Helvetica Neue", Sans-Serif; fill: #38bdae;
+    }
+    @supports(-moz-appearance: auto) {
+      /* Selector detects Firefox */
+      .stat { font-size:12px; }
+    }
+    .stagger {
+      opacity: 0;
+      animation: fadeInAnimation 0.3s ease-in-out forwards;
+    }
+    .rank-text {
+      font: 800 24px 'Segoe UI', Ubuntu, Sans-Serif; fill: #38bdae;
+      animation: scaleInAnimation 0.3s ease-in-out forwards;
+    }
+    .rank-percentile-header {
+      font-size: 14px;
+    }
+    .rank-percentile-text {
+      font-size: 16px;
+    }
+    
+    .not_bold { font-weight: 400 }
+    .bold { font-weight: 700 }
+    .icon {
+      fill: #bf91f3;
+      display: block;
+    }
+
+    .rank-circle-rim {
+      stroke: #70a5fd;
+      fill: none;
+      stroke-width: 6;
+      opacity: 0.2;
+    }
+    .rank-circle {
+      stroke: #70a5fd;
+      stroke-dasharray: 250;
+      fill: none;
+      stroke-width: 6;
+      stroke-linecap: round;
+      opacity: 0.8;
+      transform-origin: -10px 8px;
+      transform: rotate(-90deg);
+      animation: rankAnimation 1s forwards ease-in-out;
+    }
+    
+    @keyframes rankAnimation {
+      from {
+        stroke-dashoffset: 251.32741228718345;
+      }
+      to {
+        stroke-dashoffset: 113.17222826770345;
+      }
+    }
+  
+  
+
+          
+      /* Animations */
+      @keyframes scaleInAnimation {
+        from {
+          transform: translate(-5px, 5px) scale(0);
+        }
+        to {
+          transform: translate(-5px, 5px) scale(1);
+        }
+      }
+      @keyframes fadeInAnimation {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
+      }
+    
+          
+        </style>
+
+        
+
+        <rect
+          data-testid="card-bg"
+          x="0.5"
+          y="0.5"
+          rx="4.5"
+          height="99%"
+          stroke="#e4e2e2"
+          width="466"
+          fill="#1a1b27"
+          stroke-opacity="0"
+        />
+
+        
+      <g
+        data-testid="card-title"
+        transform="translate(25, 35)"
+      >
+        <g transform="translate(0, 0)">
+      <text
+        x="0"
+        y="0"
+        class="header"
+        data-testid="header"
+      >Aashir&#39;s GitHub Stats</text>
+    </g>
+      </g>
+    
+
+        <g
+          data-testid="main-card-body"
+          transform="translate(0, 55)"
+        >
+          
+    <g data-testid="rank-circle"
+          transform="translate(390.5, 72.5)">
+        <circle class="rank-circle-rim" cx="-10" cy="8" r="40" />
+        <circle class="rank-circle" cx="-10" cy="8" r="40" />
+        <g class="rank-text">
+          
+        <text x="-5" y="3" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="level-rank-icon">
+          B+
+        </text>
+      
+        </g>
+      </g>
+    <svg x="0" y="0">
+      <g transform="translate(0, 0)">
+    <g class="stagger" style="animation-delay: 450ms" transform="translate(25, 0)">
+      
+    <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
+      <path fill-rule="evenodd" d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z"/>
+    </svg>
+  
+      <text class="stat  bold" x="25" y="12.5">Total Stars Earned:</text>
+      <text
+        class="stat  bold"
+        x="224.01"
+        y="12.5"
+        data-testid="stars"
+      >16</text>
+    </g>
+  </g><g transform="translate(0, 25)">
+    <g class="stagger" style="animation-delay: 600ms" transform="translate(25, 0)">
+      
+    <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
+      <path fill-rule="evenodd" d="M1.643 3.143L.427 1.927A.25.25 0 000 2.104V5.75c0 .138.112.25.25.25h3.646a.25.25 0 00.177-.427L2.715 4.215a6.5 6.5 0 11-1.18 4.458.75.75 0 10-1.493.154 8.001 8.001 0 101.6-5.684zM7.75 4a.75.75 0 01.75.75v2.992l2.028.812a.75.75 0 01-.557 1.392l-2.5-1A.75.75 0 017 8.25v-3.5A.75.75 0 017.75 4z"/>
+    </svg>
+  
+      <text class="stat  bold" x="25" y="12.5">Total Commits:</text>
+      <text
+        class="stat  bold"
+        x="224.01"
+        y="12.5"
+        data-testid="commits"
+      >4784</text>
+    </g>
+  </g><g transform="translate(0, 50)">
+    <g class="stagger" style="animation-delay: 750ms" transform="translate(25, 0)">
+      
+    <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
+      <path fill-rule="evenodd" d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
+    </svg>
+  
+      <text class="stat  bold" x="25" y="12.5">Total PRs:</text>
+      <text
+        class="stat  bold"
+        x="224.01"
+        y="12.5"
+        data-testid="prs"
+      >390</text>
+    </g>
+  </g><g transform="translate(0, 75)">
+    <g class="stagger" style="animation-delay: 900ms" transform="translate(25, 0)">
+      
+    <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
+      <path fill-rule="evenodd" d="M5.45 5.154A4.25 4.25 0 0 0 9.25 7.5h1.378a2.251 2.251 0 1 1 0 1.5H9.25A5.734 5.734 0 0 1 5 7.123v3.505a2.25 2.25 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.95-.218ZM4.25 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm8.5-4.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 3.25a.75.75 0 1 0 0 .005V3.25Z" />
+    </svg>
+  
+      <text class="stat  bold" x="25" y="12.5">Total PRs Merged:</text>
+      <text
+        class="stat  bold"
+        x="224.01"
+        y="12.5"
+        data-testid="prs_merged"
+      >322</text>
+    </g>
+  </g><g transform="translate(0, 100)">
+    <g class="stagger" style="animation-delay: 1050ms" transform="translate(25, 0)">
+      
+    <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
+      <path fill-rule="evenodd" d="M8 2c1.981 0 3.671.992 4.933 2.078 1.27 1.091 2.187 2.345 2.637 3.023a1.62 1.62 0 0 1 0 1.798c-.45.678-1.367 1.932-2.637 3.023C11.67 13.008 9.981 14 8 14c-1.981 0-3.671-.992-4.933-2.078C1.797 10.83.88 9.576.43 8.898a1.62 1.62 0 0 1 0-1.798c.45-.677 1.367-1.931 2.637-3.022C4.33 2.992 6.019 2 8 2ZM1.679 7.932a.12.12 0 0 0 0 .136c.411.622 1.241 1.75 2.366 2.717C5.176 11.758 6.527 12.5 8 12.5c1.473 0 2.825-.742 3.955-1.715 1.124-.967 1.954-2.096 2.366-2.717a.12.12 0 0 0 0-.136c-.412-.621-1.242-1.75-2.366-2.717C10.824 4.242 9.473 3.5 8 3.5c-1.473 0-2.825.742-3.955 1.715-1.124.967-1.954 2.096-2.366 2.717ZM8 10a2 2 0 1 1-.001-3.999A2 2 0 0 1 8 10Z"/>
+    </svg>
+  
+      <text class="stat  bold" x="25" y="12.5">Total PRs Reviewed:</text>
+      <text
+        class="stat  bold"
+        x="224.01"
+        y="12.5"
+        data-testid="reviews"
+      >0</text>
+    </g>
+  </g><g transform="translate(0, 125)">
+    <g class="stagger" style="animation-delay: 1200ms" transform="translate(25, 0)">
+      
+    <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
+      <path fill-rule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm9 3a1 1 0 11-2 0 1 1 0 012 0zm-.25-6.25a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z"/>
+    </svg>
+  
+      <text class="stat  bold" x="25" y="12.5">Total Issues:</text>
+      <text
+        class="stat  bold"
+        x="224.01"
+        y="12.5"
+        data-testid="issues"
+      >5</text>
+    </g>
+  </g><g transform="translate(0, 150)">
+    <g class="stagger" style="animation-delay: 1350ms" transform="translate(25, 0)">
+      
+    <svg data-testid="icon" class="icon" viewBox="0 0 16 16" version="1.1" width="16" height="16">
+      <path fill-rule="evenodd" d="M2 2.5A2.5 2.5 0 014.5 0h8.75a.75.75 0 01.75.75v12.5a.75.75 0 01-.75.75h-2.5a.75.75 0 110-1.5h1.75v-2h-8a1 1 0 00-.714 1.7.75.75 0 01-1.072 1.05A2.495 2.495 0 012 11.5v-9zm10.5-1V9h-8c-.356 0-.694.074-1 .208V2.5a1 1 0 011-1h8zM5 12.25v3.25a.25.25 0 00.4.2l1.45-1.087a.25.25 0 01.3 0L8.6 15.7a.25.25 0 00.4-.2v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25z"/>
+    </svg>
+  
+      <text class="stat  bold" x="25" y="12.5">Contributed to (last year):</text>
+      <text
+        class="stat  bold"
+        x="224.01"
+        y="12.5"
+        data-testid="contribs"
+      >67</text>
+    </g>
+  </g>
+    </svg>
+  
+        </g>
+      </svg>
+    

--- a/scripts/normalize-profile-stats.mjs
+++ b/scripts/normalize-profile-stats.mjs
@@ -85,7 +85,11 @@ if (readCardValue("prs_merged") !== mergedPullRequests) {
 }
 
 replaceCardValue("contribs", allRepositories);
-svg = svg.replaceAll("Contributed to:", "All Repositories:");
+svg = svg.replaceAll(/Contributed to(?: \(last year\))?:/g, "All Repositories:");
+
+if (!svg.includes("All Repositories:")) {
+  throw new Error("Generated card is missing the all-repositories label");
+}
 
 await writeFile(statsPath, svg);
 console.log(

--- a/scripts/normalize-profile-stats.mjs
+++ b/scripts/normalize-profile-stats.mjs
@@ -77,23 +77,38 @@ const totalPullRequests = profile.pullRequests.totalCount;
 const mergedPullRequests = profile.mergedPullRequests.totalCount;
 const allRepositories = profile.repositories.totalCount;
 
-if (readCardValue("prs") !== totalPullRequests) {
-  throw new Error("Generated card did not include all authenticated pull requests");
-}
-if (readCardValue("prs_merged") !== mergedPullRequests) {
-  throw new Error("Generated card did not include all authenticated merged pull requests");
-}
-
+readCardValue("prs");
+readCardValue("prs_merged");
+replaceCardValue("prs", totalPullRequests);
+replaceCardValue("prs_merged", mergedPullRequests);
 replaceCardValue("contribs", allRepositories);
+svg = svg.replaceAll(
+  /Total PRs: [\d,]+ ?(?=Total PRs Merged:)/g,
+  `Total PRs: ${totalPullRequests}, `,
+);
+svg = svg.replaceAll(
+  /Total PRs Merged: [\d,]+ ?(?=Total Issues:)/g,
+  `Total PRs Merged: ${mergedPullRequests}, `,
+);
 svg = svg.replaceAll(/Contributed to(?: \(last year\))?:/g, "All Repositories:");
 svg = svg.replaceAll(
   /All Repositories: [\d,]+/g,
   `All Repositories: ${allRepositories}`,
 );
 
-if (!svg.includes(`All Repositories: ${allRepositories}</desc>`)) {
-  throw new Error("Generated card accessibility text has the wrong repository total");
+const description = svg.match(/<desc[^>]*>([^<]*)<\/desc>/)?.[1];
+if (
+  !description?.includes(
+    `Total PRs: ${totalPullRequests}, Total PRs Merged: ${mergedPullRequests},`,
+  ) ||
+  !description.includes(`All Repositories: ${allRepositories}`)
+) {
+  throw new Error(
+    `Generated card accessibility text has stale authenticated totals: ${description}`,
+  );
 }
+
+svg = `${svg.replace(/[ \t]+$/gm, "").trim()}\n`;
 
 await writeFile(statsPath, svg);
 console.log(

--- a/scripts/normalize-profile-stats.mjs
+++ b/scripts/normalize-profile-stats.mjs
@@ -86,9 +86,13 @@ if (readCardValue("prs_merged") !== mergedPullRequests) {
 
 replaceCardValue("contribs", allRepositories);
 svg = svg.replaceAll(/Contributed to(?: \(last year\))?:/g, "All Repositories:");
+svg = svg.replaceAll(
+  /All Repositories: [\d,]+/g,
+  `All Repositories: ${allRepositories}`,
+);
 
-if (!svg.includes("All Repositories:")) {
-  throw new Error("Generated card is missing the all-repositories label");
+if (!svg.includes(`All Repositories: ${allRepositories}</desc>`)) {
+  throw new Error("Generated card accessibility text has the wrong repository total");
 }
 
 await writeFile(statsPath, svg);

--- a/scripts/normalize-profile-stats.mjs
+++ b/scripts/normalize-profile-stats.mjs
@@ -1,0 +1,93 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const token = process.env.PROFILE_STATS_TOKEN;
+const username = process.env.PROFILE_STATS_USERNAME ?? "Aaxhirrr";
+const statsPath = "profile/stats.svg";
+
+if (!token) {
+  throw new Error("PROFILE_STATS_TOKEN is required");
+}
+
+const query = `
+  query ProfileStats($login: String!) {
+    user(login: $login) {
+      pullRequests {
+        totalCount
+      }
+      mergedPullRequests: pullRequests(states: MERGED) {
+        totalCount
+      }
+      repositories(
+        ownerAffiliations: [OWNER, ORGANIZATION_MEMBER, COLLABORATOR]
+      ) {
+        totalCount
+      }
+    }
+  }
+`;
+
+const response = await fetch("https://api.github.com/graphql", {
+  method: "POST",
+  headers: {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "User-Agent": "Aaxhirrr-profile-stats",
+  },
+  body: JSON.stringify({ query, variables: { login: username } }),
+});
+
+if (!response.ok) {
+  throw new Error(`GitHub GraphQL request failed with HTTP ${response.status}`);
+}
+
+const payload = await response.json();
+if (payload.errors?.length) {
+  throw new Error(`GitHub GraphQL request failed: ${payload.errors[0].message}`);
+}
+
+const profile = payload.data?.user;
+if (!profile) {
+  throw new Error(`GitHub user ${username} was not found`);
+}
+
+let svg = await readFile(statsPath, "utf8");
+
+const readCardValue = (id) => {
+  const match = svg.match(
+    new RegExp(`<text[^>]*data-testid=["']${id}["'][^>]*>([^<]*)</text>`),
+  );
+  if (!match) {
+    throw new Error(`Generated card is missing the ${id} statistic`);
+  }
+  return Number(match[1].trim().replaceAll(",", ""));
+};
+
+const replaceCardValue = (id, value) => {
+  const pattern = new RegExp(
+    `(<text[^>]*data-testid=["']${id}["'][^>]*>)[^<]*(</text>)`,
+  );
+  if (!pattern.test(svg)) {
+    throw new Error(`Generated card is missing the ${id} statistic`);
+  }
+  svg = svg.replace(pattern, `$1${value}$2`);
+};
+
+const totalPullRequests = profile.pullRequests.totalCount;
+const mergedPullRequests = profile.mergedPullRequests.totalCount;
+const allRepositories = profile.repositories.totalCount;
+
+if (readCardValue("prs") !== totalPullRequests) {
+  throw new Error("Generated card did not include all authenticated pull requests");
+}
+if (readCardValue("prs_merged") !== mergedPullRequests) {
+  throw new Error("Generated card did not include all authenticated merged pull requests");
+}
+
+replaceCardValue("contribs", allRepositories);
+svg = svg.replaceAll("Contributed to:", "All Repositories:");
+
+await writeFile(statsPath, svg);
+console.log(
+  `Verified ${totalPullRequests} PRs, ${mergedPullRequests} merged PRs, and ${allRepositories} accessible repositories.`,
+);


### PR DESCRIPTION
## What changed
- replaces the public-only stats endpoint with a repository-owned SVG
- counts authenticated public and private activity across owner, organization-member, and collaborator repositories
- shows exact totals for PRs, merged PRs, commits, issues, stars, and all accessible repositories
- refreshes daily through GitHub Actions
- keeps the credential only in the encrypted `PROFILE_STATS_TOKEN` Actions secret
- pins third-party actions and the stats renderer to immutable versions

## Verified totals
- 391 total PRs
- 322 merged PRs
- 4,784 commits
- 67 accessible repositories

## Verification
- three successful branch workflow runs
- generated SVG values match authenticated GraphQL totals
- accessibility description matches visible totals
- workflow YAML and Node script syntax validated
- credential scan clean
- `git diff --check` passes