### PR TITLE
Consolidate profile activity into Cool Stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,11 @@ Also contribute to open-source from time to time, especially for Google's gemini
   </a>
 </p>
 
-![GitHub Streak](https://streak-stats.demolab.com?user=Aaxhirrr&theme=tokyonight&hide_border=true)
-
 ---
 
 ## 🧠 LeetCode
 
 ![LeetCode Stats](https://img.shields.io/badge/LeetCode%20Stats-Loading...-darkorange?style=for-the-badge&logo=leetcode&logoColor=white)
-
----
-
-## 📊 Live Contribution Overview
-
-![](https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=Aaxhirrr&theme=tokyonight)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ Also contribute to open-source from time to time, especially for Google's gemini
 
 ---
 
-## 🚀 GitHub Dashboard
+## 📊 Cool Stats
 
-[![Aashir's private-inclusive GitHub Stats](./profile/stats.svg)](https://github.com/Aaxhirrr)
+<p align="center">
+  <a href="https://github.com/Aaxhirrr">
+    <img src="./profile/stats.svg" alt="Aashir's A++ private-inclusive GitHub stats" width="100%">
+  </a>
+</p>
 
 ![GitHub Streak](https://streak-stats.demolab.com?user=Aaxhirrr&theme=tokyonight&hide_border=true)
-
-<!-- ![Metrics](https://raw.githubusercontent.com/Aaxhirrr/Aaxhirrr/main/github-metrics.svg) -->
 
 ---
 
@@ -32,7 +34,7 @@ Also contribute to open-source from time to time, especially for Google's gemini
 
 ---
 
-## 📊 Live Contribution Overview 
+## 📊 Live Contribution Overview
 
 ![](https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=Aaxhirrr&theme=tokyonight)
 


### PR DESCRIPTION
## What changed
- renames `GitHub Dashboard` to `Cool Stats`
- expands the authenticated A++ stats card to full width
- removes the duplicate streak card
- removes the duplicate live contribution overview
- keeps LeetCode and the 2026 contribution snake as separate sections

## Verification
- authenticated private-inclusive SVG remains the single stats source
- README diff passes `git diff --check`
- two rollback checkpoints included