### PR TITLE
Refine the profile Stats card

### DIFF
--- a/.github/workflows/private-stats.yml
+++ b/.github/workflows/private-stats.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add profile/cool-stats.svg
+          git add profile/github-stats.svg
           git diff --cached --quiet && exit 0
           git commit -m "Update profile stats [skip ci]"
           git push

--- a/.github/workflows/private-stats.yml
+++ b/.github/workflows/private-stats.yml
@@ -1,4 +1,4 @@
-name: Update unified Cool Stats
+name: Update profile stats
 
 on:
   schedule:
@@ -37,5 +37,5 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add profile/cool-stats.svg
           git diff --cached --quiet && exit 0
-          git commit -m "Update unified Cool Stats [skip ci]"
+          git commit -m "Update profile stats [skip ci]"
           git push

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Also contribute to open-source from time to time, especially for Google's gemini
 
 ---
 
-## 📊 Cool Stats
+## 📊 Stats
 
 <p align="center">
   <a href="https://github.com/Aaxhirrr">
-    <img src="./profile/cool-stats.svg" alt="Aashir's unified A++ GitHub stats, contribution streaks, and activity timeline" width="100%">
+    <img src="./profile/cool-stats.svg" alt="Aashir's A++ GitHub stats, contribution streaks, and activity timeline" width="100%">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Also contribute to open-source from time to time, especially for Google's gemini
 
 <p align="center">
   <a href="https://github.com/Aaxhirrr">
-    <img src="./profile/cool-stats.svg" alt="Aashir's A++ GitHub stats, contribution streaks, and activity timeline" width="100%">
+    <img src="./profile/github-stats.svg" alt="Aashir's A++ GitHub stats, contribution streaks, and activity timeline" width="100%">
   </a>
 </p>
 

--- a/profile/cool-stats.svg
+++ b/profile/cool-stats.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1100" height="700" viewBox="0 0 1100 700" role="img" aria-labelledby="titleId descId">
   <title id="titleId">Aashir Javed&apos;s Stats, Grade A++</title>
-  <desc id="descId">Grade A++, 4,811 commits, 396 pull requests, 329 merged pull requests, 67 repositories, 1,773,105 lines changed across authored pull requests, 5,224 contributions, 33 day current streak, 44 day longest streak</desc>
+  <desc id="descId">Grade A++, 396 pull requests, 329 merged pull requests, 67 repositories, 1,773,105 lines changed across authored pull requests, 5,224 contributions, 33 day current streak, 44 day longest streak</desc>
   <defs>
     <linearGradient id="activity-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#bf91f3" stop-opacity="0.72"/>
@@ -34,31 +34,21 @@
   </g>
 
   <g transform="translate(238 155)">
-    <text class="metric-value" data-testid="commits">4,811</text>
-    <text class="metric-label" y="28">TOTAL COMMITS</text>
-  </g>
-
-  <g transform="translate(420 155)">
     <text class="metric-value" data-testid="prs">396</text>
     <text class="metric-label" y="28">TOTAL PRS</text>
   </g>
 
-  <g transform="translate(602 155)">
+  <g transform="translate(420 155)">
     <text class="metric-value" data-testid="prs_merged">329</text>
     <text class="metric-label" y="28">PRS MERGED</text>
   </g>
 
   <g transform="translate(56 248)">
-    <text class="metric-value" data-testid="issues">5</text>
-    <text class="metric-label" y="28">TOTAL ISSUES</text>
-  </g>
-
-  <g transform="translate(302 248)">
     <text class="metric-value" data-testid="repos">67</text>
     <text class="metric-label" y="28">ALL REPOSITORIES</text>
   </g>
 
-  <g transform="translate(548 248)">
+  <g transform="translate(302 248)">
     <text class="metric-value" data-testid="lines_changed">1.8M</text>
     <text class="metric-label" y="28">PR LINES CHANGED</text>
   </g>

--- a/profile/cool-stats.svg
+++ b/profile/cool-stats.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1100" height="700" viewBox="0 0 1100 700" role="img" aria-labelledby="titleId descId">
-  <title id="titleId">Aashir Javed&apos;s Cool Stats, Grade A++</title>
-  <desc id="descId">Grade A++, 4,807 commits, 396 pull requests, 329 merged pull requests, 67 repositories, 1,773,105 lines changed across authored pull requests, 5,224 contributions, 33 day current streak, 44 day longest streak</desc>
+  <title id="titleId">Aashir Javed&apos;s Stats, Grade A++</title>
+  <desc id="descId">Grade A++, 4,811 commits, 396 pull requests, 329 merged pull requests, 67 repositories, 1,773,105 lines changed across authored pull requests, 5,224 contributions, 33 day current streak, 44 day longest streak</desc>
   <defs>
     <linearGradient id="activity-fill" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%" stop-color="#bf91f3" stop-opacity="0.72"/>
@@ -23,7 +23,7 @@
 
   <rect x="0.5" y="0.5" width="1099" height="699" rx="18" fill="#161822" stroke="#2d333b"/>
 
-  <text class="title" x="56" y="58">Aashir Javed&apos;s Cool Stats</text>
+  <text class="title" x="56" y="58">Stats</text>
   <text class="eyebrow" x="56" y="86">PUBLIC + PRIVATE GITHUB ACTIVITY</text>
   <text class="eyebrow" x="1044" y="58" text-anchor="end">UPDATED AUG 9, 2026</text>
 
@@ -34,7 +34,7 @@
   </g>
 
   <g transform="translate(238 155)">
-    <text class="metric-value" data-testid="commits">4,807</text>
+    <text class="metric-value" data-testid="commits">4,811</text>
     <text class="metric-label" y="28">TOTAL COMMITS</text>
   </g>
 

--- a/profile/cool-stats.svg
+++ b/profile/cool-stats.svg
@@ -1,96 +1,99 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="700" viewBox="0 0 1100 700" role="img" aria-labelledby="titleId descId">
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="660" viewBox="0 0 1100 660" role="img" aria-labelledby="titleId descId">
   <title id="titleId">Aashir Javed&apos;s Stats, Grade A++</title>
   <desc id="descId">Grade A++, 396 pull requests, 329 merged pull requests, 67 repositories, 1,773,105 lines changed across authored pull requests, 5,224 contributions, 33 day current streak, 44 day longest streak</desc>
   <defs>
     <linearGradient id="activity-fill" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#bf91f3" stop-opacity="0.72"/>
-      <stop offset="100%" stop-color="#bf91f3" stop-opacity="0.04"/>
+      <stop offset="0%" stop-color="#bf91f3" stop-opacity="0.46"/>
+      <stop offset="100%" stop-color="#bf91f3" stop-opacity="0.02"/>
+    </linearGradient>
+    <linearGradient id="activity-line" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#70a5fd"/>
+      <stop offset="100%" stop-color="#bf91f3"/>
     </linearGradient>
   </defs>
   <style>
     text { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", sans-serif; }
-    .title { fill: #70a5fd; font-size: 29px; font-weight: 700; letter-spacing: -0.4px; }
-    .eyebrow { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; font-weight: 600; letter-spacing: 1.4px; }
-    .metric-value { fill: #f0f6fc; font-size: 34px; font-weight: 720; letter-spacing: -0.6px; }
-    .metric-label { fill: #38bdae; font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; font-weight: 650; letter-spacing: 0.8px; }
-    .grade { fill: #38bdae; font-size: 42px; font-weight: 800; letter-spacing: -1px; }
-    .streak-value { fill: #70a5fd; font-size: 36px; font-weight: 760; letter-spacing: -0.6px; }
-    .streak-label { fill: #f0f6fc; font-size: 15px; font-weight: 650; }
-    .streak-date { fill: #38bdae; font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; }
-    .chart-label { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; }
+    .title { fill: #f0f6fc; font-size: 44px; font-weight: 760; letter-spacing: -1.2px; }
+    .kicker, .eyebrow, .metric-label, .section-label, .grade-label { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; font-weight: 650; letter-spacing: 1.15px; }
+    .metric-value { fill: #f0f6fc; font-size: 38px; font-weight: 760; letter-spacing: -0.8px; }
+    .grade-value { fill: #70a5fd; font-size: 52px; font-weight: 820; letter-spacing: -1.6px; }
+    .streak-value { fill: #f0f6fc; font-size: 38px; font-weight: 760; letter-spacing: -0.8px; }
+    .streak-current { fill: #38bdae; }
+    .streak-longest { fill: #70a5fd; }
+    .streak-note { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; letter-spacing: 0.2px; }
+    .chart-label { fill: #6e7681; font-family: "SFMono-Regular", Consolas, monospace; font-size: 10px; }
     .footer { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; }
   </style>
 
-  <rect x="0.5" y="0.5" width="1099" height="699" rx="18" fill="#161822" stroke="#2d333b"/>
+  <rect width="1100" height="660" rx="20" fill="#11131b"/>
+  <rect x="56" y="28" width="54" height="3" rx="1.5" fill="#70a5fd"/>
+  <rect x="116" y="28" width="26" height="3" rx="1.5" fill="#bf91f3"/>
 
-  <text class="title" x="56" y="58">Stats</text>
-  <text class="eyebrow" x="56" y="86">PUBLIC + PRIVATE GITHUB ACTIVITY</text>
+  <text class="kicker" x="56" y="58">AASHIR JAVED / GITHUB</text>
+  <text class="title" x="56" y="112">Stats</text>
+  <text class="eyebrow" x="56" y="136">PUBLIC + PRIVATE ACTIVITY</text>
   <text class="eyebrow" x="1044" y="58" text-anchor="end">UPDATED AUG 9, 2026</text>
+  <text class="grade-label" x="1044" y="88" text-anchor="end">PROFILE GRADE</text>
+  <text class="grade-value" data-testid="grade" x="1044" y="132" text-anchor="end">A++</text>
 
+  <line x1="56" y1="154" x2="1044" y2="154" stroke="#262b36"/>
 
-  <g transform="translate(56 155)">
-    <text class="metric-value" data-testid="stars">16</text>
-    <text class="metric-label" y="28">TOTAL STARS</text>
+  <g transform="translate(56 176)">
+    <text class="metric-label">STARS</text>
+    <text class="metric-value" data-testid="stars" y="45">16</text>
   </g>
 
-  <g transform="translate(238 155)">
-    <text class="metric-value" data-testid="prs">396</text>
-    <text class="metric-label" y="28">TOTAL PRS</text>
+  <g transform="translate(254 176)">
+    <text class="metric-label">PULL REQUESTS</text>
+    <text class="metric-value" data-testid="prs" y="45">396</text>
   </g>
 
-  <g transform="translate(420 155)">
-    <text class="metric-value" data-testid="prs_merged">329</text>
-    <text class="metric-label" y="28">PRS MERGED</text>
+  <g transform="translate(452 176)">
+    <text class="metric-label">MERGED PRS</text>
+    <text class="metric-value" data-testid="prs_merged" y="45">329</text>
   </g>
 
-  <g transform="translate(56 248)">
-    <text class="metric-value" data-testid="repos">67</text>
-    <text class="metric-label" y="28">ALL REPOSITORIES</text>
+  <g transform="translate(650 176)">
+    <text class="metric-label">REPOSITORIES</text>
+    <text class="metric-value" data-testid="repos" y="45">67</text>
   </g>
 
-  <g transform="translate(302 248)">
-    <text class="metric-value" data-testid="lines_changed">1.8M</text>
-    <text class="metric-label" y="28">PR LINES CHANGED</text>
+  <g transform="translate(848 176)">
+    <text class="metric-label">PR LINES CHANGED</text>
+    <text class="metric-value" data-testid="lines_changed" y="45">1.8M</text>
   </g>
 
-  <g transform="translate(920 206)">
-    <circle r="71" fill="none" stroke="#2e3855" stroke-width="12"/>
-    <circle r="71" fill="none" stroke="#70a5fd" stroke-width="12" stroke-linecap="round"/>
-    <text class="grade" data-testid="grade" text-anchor="middle" dominant-baseline="central">A++</text>
-    <text class="eyebrow" y="103" text-anchor="middle">GRADE</text>
+  <line x1="56" y1="269" x2="1044" y2="269" stroke="#262b36"/>
+
+  <g transform="translate(56 307)">
+    <text class="section-label">TOTAL CONTRIBUTIONS</text>
+    <text class="streak-value" data-testid="total_contributions" y="50">5,224</text>
+    <text class="streak-note" y="79">SINCE NOV 2023</text>
+  </g>
+  <g transform="translate(420 307)">
+    <text class="section-label">CURRENT STREAK</text>
+    <text class="streak-value streak-current" data-testid="current_streak" y="50">33 days</text>
+    <text class="streak-note" y="79">JUL 8 – AUG 9</text>
+  </g>
+  <g transform="translate(784 307)">
+    <text class="section-label">LONGEST STREAK</text>
+    <text class="streak-value streak-longest" data-testid="longest_streak" y="50">44 days</text>
+    <text class="streak-note" y="79">JUN 21 – AUG 3</text>
   </g>
 
-  <line x1="56" y1="327" x2="1044" y2="327" stroke="#2d333b"/>
+  <line x1="56" y1="418" x2="1044" y2="418" stroke="#262b36"/>
+  <text class="eyebrow" x="56" y="454">CONTRIBUTIONS · LAST 12 MONTHS</text>
+  <text class="eyebrow" x="1044" y="454" text-anchor="end">PEAK 948 / WEEK</text>
+  <line x1="56" y1="578" x2="1044" y2="578" stroke="#262b36"/>
+  <path d="M56.0 576.2 L75.4 575.3 L94.7 576.5 L114.1 576.8 L133.5 577.0 L152.9 577.3 L172.2 575.6 L191.6 576.6 L211.0 574.8 L230.4 577.2 L249.7 577.3 L269.1 577.3 L288.5 576.5 L307.8 575.6 L327.2 577.0 L346.6 577.5 L366.0 577.1 L385.3 577.1 L404.7 577.3 L424.1 577.3 L443.5 577.2 L462.8 575.6 L482.2 577.5 L501.6 575.7 L520.9 576.9 L540.3 575.5 L559.7 575.6 L579.1 575.1 L598.4 571.9 L617.8 575.0 L637.2 575.0 L656.5 574.7 L675.9 574.4 L695.3 574.3 L714.7 576.8 L734.0 575.4 L753.4 572.0 L772.8 576.8 L792.2 577.5 L811.5 576.7 L830.9 576.5 L850.3 573.8 L869.6 574.3 L889.0 574.7 L908.4 571.0 L927.8 573.9 L947.1 572.6 L966.5 544.9 L985.9 474.0 L1005.3 494.0 L1024.6 511.3 L1044.0 539.7 L1044 578 L56 578 Z" fill="url(#activity-fill)"/>
+  <path d="M56.0 576.2 L75.4 575.3 L94.7 576.5 L114.1 576.8 L133.5 577.0 L152.9 577.3 L172.2 575.6 L191.6 576.6 L211.0 574.8 L230.4 577.2 L249.7 577.3 L269.1 577.3 L288.5 576.5 L307.8 575.6 L327.2 577.0 L346.6 577.5 L366.0 577.1 L385.3 577.1 L404.7 577.3 L424.1 577.3 L443.5 577.2 L462.8 575.6 L482.2 577.5 L501.6 575.7 L520.9 576.9 L540.3 575.5 L559.7 575.6 L579.1 575.1 L598.4 571.9 L617.8 575.0 L637.2 575.0 L656.5 574.7 L675.9 574.4 L695.3 574.3 L714.7 576.8 L734.0 575.4 L753.4 572.0 L772.8 576.8 L792.2 577.5 L811.5 576.7 L830.9 576.5 L850.3 573.8 L869.6 574.3 L889.0 574.7 L908.4 571.0 L927.8 573.9 L947.1 572.6 L966.5 544.9 L985.9 474.0 L1005.3 494.0 L1024.6 511.3 L1044.0 539.7" fill="none" stroke="url(#activity-line)" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>
+  <text class="chart-label" x="56.0" y="607" text-anchor="middle">Aug</text>
+<text class="chart-label" x="249.7" y="607" text-anchor="middle">Oct</text>
+<text class="chart-label" x="443.5" y="607" text-anchor="middle">Dec</text>
+<text class="chart-label" x="637.2" y="607" text-anchor="middle">Mar</text>
+<text class="chart-label" x="830.9" y="607" text-anchor="middle">May</text>
+<text class="chart-label" x="1044.0" y="607" text-anchor="middle">Aug</text>
 
-  <g transform="translate(56 381)">
-    <text class="streak-value" data-testid="total_contributions">5,224</text>
-    <text class="streak-label" y="30">Total contributions</text>
-    <text class="streak-date" y="55">Since Nov 2023</text>
-  </g>
-  <g transform="translate(403 381)">
-    <text class="streak-value" data-testid="current_streak">33 days</text>
-    <text class="streak-label" y="30">Current streak</text>
-    <text class="streak-date" y="55">Jul 8 – Aug 9</text>
-  </g>
-  <g transform="translate(748 381)">
-    <text class="streak-value" data-testid="longest_streak">44 days</text>
-    <text class="streak-label" y="30">Longest streak</text>
-    <text class="streak-date" y="55">Jun 21 – Aug 3</text>
-  </g>
-
-  <line x1="56" y1="470" x2="1044" y2="470" stroke="#2d333b"/>
-  <text class="eyebrow" x="56" y="509">CONTRIBUTION VELOCITY · LAST 12 MONTHS</text>
-  <text class="eyebrow" x="1044" y="509" text-anchor="end">PEAK 948 / WEEK</text>
-  <line x1="56" y1="624" x2="1044" y2="624" stroke="#2d333b"/>
-  <path d="M56.0 622.4 L75.4 621.6 L94.7 622.6 L114.1 622.9 L133.5 623.1 L152.9 623.4 L172.2 621.9 L191.6 622.7 L211.0 621.2 L230.4 623.3 L249.7 623.4 L269.1 623.4 L288.5 622.6 L307.8 621.9 L327.2 623.1 L346.6 623.5 L366.0 623.2 L385.3 623.2 L404.7 623.4 L424.1 623.4 L443.5 623.3 L462.8 621.9 L482.2 623.5 L501.6 622.0 L520.9 623.0 L540.3 621.8 L559.7 621.9 L579.1 621.5 L598.4 618.6 L617.8 621.4 L637.2 621.4 L656.5 621.1 L675.9 620.8 L695.3 620.7 L714.7 622.9 L734.0 621.7 L753.4 618.7 L772.8 622.9 L792.2 623.5 L811.5 622.8 L830.9 622.6 L850.3 620.3 L869.6 620.7 L889.0 621.1 L908.4 617.8 L927.8 620.4 L947.1 619.2 L966.5 594.7 L985.9 532.0 L1005.3 549.7 L1024.6 565.0 L1044.0 590.1 L1044 624 L56 624 Z" fill="url(#activity-fill)"/>
-  <path d="M56.0 622.4 L75.4 621.6 L94.7 622.6 L114.1 622.9 L133.5 623.1 L152.9 623.4 L172.2 621.9 L191.6 622.7 L211.0 621.2 L230.4 623.3 L249.7 623.4 L269.1 623.4 L288.5 622.6 L307.8 621.9 L327.2 623.1 L346.6 623.5 L366.0 623.2 L385.3 623.2 L404.7 623.4 L424.1 623.4 L443.5 623.3 L462.8 621.9 L482.2 623.5 L501.6 622.0 L520.9 623.0 L540.3 621.8 L559.7 621.9 L579.1 621.5 L598.4 618.6 L617.8 621.4 L637.2 621.4 L656.5 621.1 L675.9 620.8 L695.3 620.7 L714.7 622.9 L734.0 621.7 L753.4 618.7 L772.8 622.9 L792.2 623.5 L811.5 622.8 L830.9 622.6 L850.3 620.3 L869.6 620.7 L889.0 621.1 L908.4 617.8 L927.8 620.4 L947.1 619.2 L966.5 594.7 L985.9 532.0 L1005.3 549.7 L1024.6 565.0 L1044.0 590.1" fill="none" stroke="#bf91f3" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>
-  <text class="chart-label" x="56.0" y="648" text-anchor="middle">Aug</text>
-<text class="chart-label" x="249.7" y="648" text-anchor="middle">Oct</text>
-<text class="chart-label" x="443.5" y="648" text-anchor="middle">Dec</text>
-<text class="chart-label" x="637.2" y="648" text-anchor="middle">Mar</text>
-<text class="chart-label" x="830.9" y="648" text-anchor="middle">May</text>
-<text class="chart-label" x="1044.0" y="648" text-anchor="middle">Aug</text>
-
-  <text class="footer" x="56" y="680">58 public · 9 private · joined Nov 2023</text>
-  <text class="footer" x="1044" y="680" text-anchor="end">Phoenix</text>
+  <text class="footer" x="56" y="642">58 public · 9 private · joined Nov 2023</text>
+  <text class="footer" x="1044" y="642" text-anchor="end">Phoenix</text>
 </svg>

--- a/profile/github-stats.svg
+++ b/profile/github-stats.svg
@@ -14,7 +14,7 @@
   <style>
     text { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", sans-serif; }
     .title { fill: #f0f6fc; font-size: 44px; font-weight: 760; letter-spacing: -1.2px; }
-    .kicker, .eyebrow, .metric-label, .section-label, .grade-label { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; font-weight: 650; letter-spacing: 1.15px; }
+    .kicker, .eyebrow, .metric-label, .section-label, .grade-label { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; font-weight: 650; letter-spacing: 1.1px; }
     .metric-value { fill: #f0f6fc; font-size: 38px; font-weight: 760; letter-spacing: -0.8px; }
     .grade-value { fill: #70a5fd; font-size: 52px; font-weight: 820; letter-spacing: -1.6px; }
     .streak-value { fill: #f0f6fc; font-size: 38px; font-weight: 760; letter-spacing: -0.8px; }

--- a/profile/github-stats.svg
+++ b/profile/github-stats.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="660" viewBox="0 0 1100 660" role="img" aria-labelledby="titleId descId">
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="660" viewBox="0 0 1100 660" role="img" aria-labelledby="titleId descId" data-theme="stats">
   <title id="titleId">Aashir Javed&apos;s Stats, Grade A++</title>
   <desc id="descId">Grade A++, 396 pull requests, 329 merged pull requests, 67 repositories, 1,773,105 lines changed across authored pull requests, 5,224 contributions, 33 day current streak, 44 day longest streak</desc>
   <defs>

--- a/scripts/normalize-profile-stats.mjs
+++ b/scripts/normalize-profile-stats.mjs
@@ -275,7 +275,7 @@ for (let index = 0; index < chartDayCount; index += 1) {
     contributionsByDate.get(dateKey(date)) ?? 0;
 }
 
-const chart = { left: 56, top: 532, width: 988, height: 92 };
+const chart = { left: 56, top: 474, width: 988, height: 104 };
 const chartBottom = chart.top + chart.height;
 const chartMaximum = Math.max(...weeklyContributions, 1);
 const chartPoints = weeklyContributions.map((value, index) => {
@@ -327,16 +327,16 @@ const updatedDate = new Intl.DateTimeFormat("en-US", {
 
 const renderMetric = ({ x, y, label, value, id }) => `
   <g transform="translate(${x} ${y})">
-    <text class="metric-value" data-testid="${id}">${escapeXml(value)}</text>
-    <text class="metric-label" y="28">${escapeXml(label)}</text>
+    <text class="metric-label">${escapeXml(label)}</text>
+    <text class="metric-value" data-testid="${id}" y="45">${escapeXml(value)}</text>
   </g>`;
 
 const metrics = [
-  { x: 56, y: 155, label: "TOTAL STARS", value: formatNumber(totalStars), id: "stars" },
-  { x: 238, y: 155, label: "TOTAL PRS", value: formatNumber(totalPullRequests), id: "prs" },
-  { x: 420, y: 155, label: "PRS MERGED", value: formatNumber(mergedPullRequests), id: "prs_merged" },
-  { x: 56, y: 248, label: "ALL REPOSITORIES", value: formatNumber(allRepositories), id: "repos" },
-  { x: 302, y: 248, label: "PR LINES CHANGED", value: formatCompactNumber(totalLinesChanged), id: "lines_changed" },
+  { x: 56, y: 176, label: "STARS", value: formatNumber(totalStars), id: "stars" },
+  { x: 254, y: 176, label: "PULL REQUESTS", value: formatNumber(totalPullRequests), id: "prs" },
+  { x: 452, y: 176, label: "MERGED PRS", value: formatNumber(mergedPullRequests), id: "prs_merged" },
+  { x: 650, y: 176, label: "REPOSITORIES", value: formatNumber(allRepositories), id: "repos" },
+  { x: 848, y: 176, label: "PR LINES CHANGED", value: formatCompactNumber(totalLinesChanged), id: "lines_changed" },
 ];
 
 const chartLabels = chartLabelIndexes
@@ -347,7 +347,7 @@ const chartLabels = chartLabelIndexes
       month: "short",
       timeZone: "UTC",
     }).format(date);
-    return `<text class="chart-label" x="${x.toFixed(1)}" y="648" text-anchor="middle">${label}</text>`;
+    return `<text class="chart-label" x="${x.toFixed(1)}" y="607" text-anchor="middle">${label}</text>`;
   })
   .join("\n");
 
@@ -363,72 +363,75 @@ const description = [
   `${streaks.longest.count} day longest streak`,
 ].join(", ");
 
-const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="700" viewBox="0 0 1100 700" role="img" aria-labelledby="titleId descId">
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="660" viewBox="0 0 1100 660" role="img" aria-labelledby="titleId descId">
   <title id="titleId">${escapeXml(titleName)}&apos;s Stats, Grade ${displayedGrade}</title>
   <desc id="descId">${escapeXml(description)}</desc>
   <defs>
     <linearGradient id="activity-fill" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#bf91f3" stop-opacity="0.72"/>
-      <stop offset="100%" stop-color="#bf91f3" stop-opacity="0.04"/>
+      <stop offset="0%" stop-color="#bf91f3" stop-opacity="0.46"/>
+      <stop offset="100%" stop-color="#bf91f3" stop-opacity="0.02"/>
+    </linearGradient>
+    <linearGradient id="activity-line" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#70a5fd"/>
+      <stop offset="100%" stop-color="#bf91f3"/>
     </linearGradient>
   </defs>
   <style>
     text { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", sans-serif; }
-    .title { fill: #70a5fd; font-size: 29px; font-weight: 700; letter-spacing: -0.4px; }
-    .eyebrow { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; font-weight: 600; letter-spacing: 1.4px; }
-    .metric-value { fill: #f0f6fc; font-size: 34px; font-weight: 720; letter-spacing: -0.6px; }
-    .metric-label { fill: #38bdae; font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; font-weight: 650; letter-spacing: 0.8px; }
-    .grade { fill: #38bdae; font-size: 42px; font-weight: 800; letter-spacing: -1px; }
-    .streak-value { fill: #70a5fd; font-size: 36px; font-weight: 760; letter-spacing: -0.6px; }
-    .streak-label { fill: #f0f6fc; font-size: 15px; font-weight: 650; }
-    .streak-date { fill: #38bdae; font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; }
-    .chart-label { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; }
+    .title { fill: #f0f6fc; font-size: 44px; font-weight: 760; letter-spacing: -1.2px; }
+    .kicker, .eyebrow, .metric-label, .section-label, .grade-label { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; font-weight: 650; letter-spacing: 1.15px; }
+    .metric-value { fill: #f0f6fc; font-size: 38px; font-weight: 760; letter-spacing: -0.8px; }
+    .grade-value { fill: #70a5fd; font-size: 52px; font-weight: 820; letter-spacing: -1.6px; }
+    .streak-value { fill: #f0f6fc; font-size: 38px; font-weight: 760; letter-spacing: -0.8px; }
+    .streak-current { fill: #38bdae; }
+    .streak-longest { fill: #70a5fd; }
+    .streak-note { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; letter-spacing: 0.2px; }
+    .chart-label { fill: #6e7681; font-family: "SFMono-Regular", Consolas, monospace; font-size: 10px; }
     .footer { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; }
   </style>
 
-  <rect x="0.5" y="0.5" width="1099" height="699" rx="18" fill="#161822" stroke="#2d333b"/>
+  <rect width="1100" height="660" rx="20" fill="#11131b"/>
+  <rect x="56" y="28" width="54" height="3" rx="1.5" fill="#70a5fd"/>
+  <rect x="116" y="28" width="26" height="3" rx="1.5" fill="#bf91f3"/>
 
-  <text class="title" x="56" y="58">Stats</text>
-  <text class="eyebrow" x="56" y="86">PUBLIC + PRIVATE GITHUB ACTIVITY</text>
+  <text class="kicker" x="56" y="58">${escapeXml(titleName.toUpperCase())} / GITHUB</text>
+  <text class="title" x="56" y="112">Stats</text>
+  <text class="eyebrow" x="56" y="136">PUBLIC + PRIVATE ACTIVITY</text>
   <text class="eyebrow" x="1044" y="58" text-anchor="end">UPDATED ${escapeXml(updatedDate.toUpperCase())}</text>
+  <text class="grade-label" x="1044" y="88" text-anchor="end">PROFILE GRADE</text>
+  <text class="grade-value" data-testid="grade" x="1044" y="132" text-anchor="end">${displayedGrade}</text>
 
+  <line x1="56" y1="154" x2="1044" y2="154" stroke="#262b36"/>
   ${metrics.map(renderMetric).join("\n")}
 
-  <g transform="translate(920 206)">
-    <circle r="71" fill="none" stroke="#2e3855" stroke-width="12"/>
-    <circle r="71" fill="none" stroke="#70a5fd" stroke-width="12" stroke-linecap="round"/>
-    <text class="grade" data-testid="grade" text-anchor="middle" dominant-baseline="central">${displayedGrade}</text>
-    <text class="eyebrow" y="103" text-anchor="middle">GRADE</text>
+  <line x1="56" y1="269" x2="1044" y2="269" stroke="#262b36"/>
+
+  <g transform="translate(56 307)">
+    <text class="section-label">TOTAL CONTRIBUTIONS</text>
+    <text class="streak-value" data-testid="total_contributions" y="50">${formatNumber(totalContributions)}</text>
+    <text class="streak-note" y="79">SINCE ${escapeXml(joinedDate.toUpperCase())}</text>
+  </g>
+  <g transform="translate(420 307)">
+    <text class="section-label">CURRENT STREAK</text>
+    <text class="streak-value streak-current" data-testid="current_streak" y="50">${streaks.current.count} days</text>
+    <text class="streak-note" y="79">${escapeXml(formatDateRange(streaks.current).toUpperCase())}</text>
+  </g>
+  <g transform="translate(784 307)">
+    <text class="section-label">LONGEST STREAK</text>
+    <text class="streak-value streak-longest" data-testid="longest_streak" y="50">${streaks.longest.count} days</text>
+    <text class="streak-note" y="79">${escapeXml(formatDateRange(streaks.longest).toUpperCase())}</text>
   </g>
 
-  <line x1="56" y1="327" x2="1044" y2="327" stroke="#2d333b"/>
-
-  <g transform="translate(56 381)">
-    <text class="streak-value" data-testid="total_contributions">${formatNumber(totalContributions)}</text>
-    <text class="streak-label" y="30">Total contributions</text>
-    <text class="streak-date" y="55">Since ${escapeXml(joinedDate)}</text>
-  </g>
-  <g transform="translate(403 381)">
-    <text class="streak-value" data-testid="current_streak">${streaks.current.count} days</text>
-    <text class="streak-label" y="30">Current streak</text>
-    <text class="streak-date" y="55">${escapeXml(formatDateRange(streaks.current))}</text>
-  </g>
-  <g transform="translate(748 381)">
-    <text class="streak-value" data-testid="longest_streak">${streaks.longest.count} days</text>
-    <text class="streak-label" y="30">Longest streak</text>
-    <text class="streak-date" y="55">${escapeXml(formatDateRange(streaks.longest))}</text>
-  </g>
-
-  <line x1="56" y1="470" x2="1044" y2="470" stroke="#2d333b"/>
-  <text class="eyebrow" x="56" y="509">CONTRIBUTION VELOCITY · LAST 12 MONTHS</text>
-  <text class="eyebrow" x="1044" y="509" text-anchor="end">PEAK ${formatNumber(chartMaximum)} / WEEK</text>
-  <line x1="${chart.left}" y1="${chartBottom}" x2="${chart.left + chart.width}" y2="${chartBottom}" stroke="#2d333b"/>
+  <line x1="56" y1="418" x2="1044" y2="418" stroke="#262b36"/>
+  <text class="eyebrow" x="56" y="454">CONTRIBUTIONS · LAST 12 MONTHS</text>
+  <text class="eyebrow" x="1044" y="454" text-anchor="end">PEAK ${formatNumber(chartMaximum)} / WEEK</text>
+  <line x1="${chart.left}" y1="${chartBottom}" x2="${chart.left + chart.width}" y2="${chartBottom}" stroke="#262b36"/>
   <path d="${areaPath}" fill="url(#activity-fill)"/>
-  <path d="${linePath}" fill="none" stroke="#bf91f3" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>
+  <path d="${linePath}" fill="none" stroke="url(#activity-line)" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>
   ${chartLabels}
 
-  <text class="footer" x="56" y="680">${publicRepositories} public · ${privateRepositories} private · joined ${escapeXml(joinedDate)}</text>
-  <text class="footer" x="1044" y="680" text-anchor="end">${escapeXml(profile.location || "GitHub")}</text>
+  <text class="footer" x="56" y="642">${publicRepositories} public · ${privateRepositories} private · joined ${escapeXml(joinedDate)}</text>
+  <text class="footer" x="1044" y="642" text-anchor="end">${escapeXml(profile.location || "GitHub")}</text>
 </svg>
 `;
 
@@ -437,10 +440,10 @@ const normalizedSvg = `${svg.replace(/[ \t]+$/gm, "").trim()}\n`;
 const requiredValues = [
   `data-testid="grade"`,
   `>${displayedGrade}</text>`,
-  `data-testid="prs">${formatNumber(totalPullRequests)}</text>`,
-  `data-testid="repos">${formatNumber(allRepositories)}</text>`,
-  `data-testid="lines_changed">${formatCompactNumber(totalLinesChanged)}</text>`,
-  `data-testid="total_contributions">${formatNumber(totalContributions)}</text>`,
+  `data-testid="prs" y="45">${formatNumber(totalPullRequests)}</text>`,
+  `data-testid="repos" y="45">${formatNumber(allRepositories)}</text>`,
+  `data-testid="lines_changed" y="45">${formatCompactNumber(totalLinesChanged)}</text>`,
+  `data-testid="total_contributions" y="50">${formatNumber(totalContributions)}</text>`,
 ];
 for (const value of requiredValues) {
   if (!normalizedSvg.includes(value)) {

--- a/scripts/normalize-profile-stats.mjs
+++ b/scripts/normalize-profile-stats.mjs
@@ -55,9 +55,6 @@ const profileQuery = `
       mergedPullRequests: pullRequests(states: MERGED) {
         totalCount
       }
-      issues {
-        totalCount
-      }
       repositories(
         first: 100
         after: $cursor
@@ -181,15 +178,10 @@ const contributionYearsPromise = Promise.all(
   }),
 );
 
-const commitSearchUrl = new URL("https://api.github.com/search/commits");
-commitSearchUrl.searchParams.set("q", `author:${username}`);
-commitSearchUrl.searchParams.set("per_page", "1");
-const commitsPromise = requestJson(commitSearchUrl);
 const pullRequestLinesPromise = fetchPullRequestLines();
 
-const [contributionYears, commitSearch, totalLinesChanged] = await Promise.all([
+const [contributionYears, totalLinesChanged] = await Promise.all([
   contributionYearsPromise,
-  commitsPromise,
   pullRequestLinesPromise,
 ]);
 
@@ -269,10 +261,8 @@ const totalStars = repositories.reduce(
   (sum, repository) => sum + repository.stargazerCount,
   0,
 );
-const totalCommits = commitSearch.total_count;
 const totalPullRequests = profile.pullRequests.totalCount;
 const mergedPullRequests = profile.mergedPullRequests.totalCount;
-const totalIssues = profile.issues.totalCount;
 
 const chartDayCount = 52 * 7;
 const today = parseDate(currentDate);
@@ -343,12 +333,10 @@ const renderMetric = ({ x, y, label, value, id }) => `
 
 const metrics = [
   { x: 56, y: 155, label: "TOTAL STARS", value: formatNumber(totalStars), id: "stars" },
-  { x: 238, y: 155, label: "TOTAL COMMITS", value: formatNumber(totalCommits), id: "commits" },
-  { x: 420, y: 155, label: "TOTAL PRS", value: formatNumber(totalPullRequests), id: "prs" },
-  { x: 602, y: 155, label: "PRS MERGED", value: formatNumber(mergedPullRequests), id: "prs_merged" },
-  { x: 56, y: 248, label: "TOTAL ISSUES", value: formatNumber(totalIssues), id: "issues" },
-  { x: 302, y: 248, label: "ALL REPOSITORIES", value: formatNumber(allRepositories), id: "repos" },
-  { x: 548, y: 248, label: "PR LINES CHANGED", value: formatCompactNumber(totalLinesChanged), id: "lines_changed" },
+  { x: 238, y: 155, label: "TOTAL PRS", value: formatNumber(totalPullRequests), id: "prs" },
+  { x: 420, y: 155, label: "PRS MERGED", value: formatNumber(mergedPullRequests), id: "prs_merged" },
+  { x: 56, y: 248, label: "ALL REPOSITORIES", value: formatNumber(allRepositories), id: "repos" },
+  { x: 302, y: 248, label: "PR LINES CHANGED", value: formatCompactNumber(totalLinesChanged), id: "lines_changed" },
 ];
 
 const chartLabels = chartLabelIndexes
@@ -366,7 +354,6 @@ const chartLabels = chartLabelIndexes
 const titleName = profile.name || profile.login;
 const description = [
   `Grade ${displayedGrade}`,
-  `${formatNumber(totalCommits)} commits`,
   `${formatNumber(totalPullRequests)} pull requests`,
   `${formatNumber(mergedPullRequests)} merged pull requests`,
   `${formatNumber(allRepositories)} repositories`,

--- a/scripts/normalize-profile-stats.mjs
+++ b/scripts/normalize-profile-stats.mjs
@@ -19,7 +19,7 @@ const headers = {
   Accept: "application/vnd.github+json",
   Authorization: `Bearer ${token}`,
   "Content-Type": "application/json",
-  "User-Agent": "Aaxhirrr-cool-stats",
+  "User-Agent": "Aaxhirrr-profile-stats",
   "X-GitHub-Api-Version": "2022-11-28",
 };
 
@@ -377,7 +377,7 @@ const description = [
 ].join(", ");
 
 const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="700" viewBox="0 0 1100 700" role="img" aria-labelledby="titleId descId">
-  <title id="titleId">${escapeXml(titleName)}&apos;s Cool Stats, Grade ${displayedGrade}</title>
+  <title id="titleId">${escapeXml(titleName)}&apos;s Stats, Grade ${displayedGrade}</title>
   <desc id="descId">${escapeXml(description)}</desc>
   <defs>
     <linearGradient id="activity-fill" x1="0" y1="0" x2="0" y2="1">
@@ -401,7 +401,7 @@ const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="700" v
 
   <rect x="0.5" y="0.5" width="1099" height="699" rx="18" fill="#161822" stroke="#2d333b"/>
 
-  <text class="title" x="56" y="58">${escapeXml(titleName)}&apos;s Cool Stats</text>
+  <text class="title" x="56" y="58">Stats</text>
   <text class="eyebrow" x="56" y="86">PUBLIC + PRIVATE GITHUB ACTIVITY</text>
   <text class="eyebrow" x="1044" y="58" text-anchor="end">UPDATED ${escapeXml(updatedDate.toUpperCase())}</text>
 
@@ -457,7 +457,7 @@ const requiredValues = [
 ];
 for (const value of requiredValues) {
   if (!normalizedSvg.includes(value)) {
-    throw new Error(`Generated Cool Stats card is missing ${value}`);
+    throw new Error(`Generated stats card is missing ${value}`);
   }
 }
 

--- a/scripts/normalize-profile-stats.mjs
+++ b/scripts/normalize-profile-stats.mjs
@@ -379,7 +379,7 @@ const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="660" v
   <style>
     text { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", sans-serif; }
     .title { fill: #f0f6fc; font-size: 44px; font-weight: 760; letter-spacing: -1.2px; }
-    .kicker, .eyebrow, .metric-label, .section-label, .grade-label { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; font-weight: 650; letter-spacing: 1.15px; }
+    .kicker, .eyebrow, .metric-label, .section-label, .grade-label { fill: #8b949e; font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; font-weight: 650; letter-spacing: 1.1px; }
     .metric-value { fill: #f0f6fc; font-size: 38px; font-weight: 760; letter-spacing: -0.8px; }
     .grade-value { fill: #70a5fd; font-size: 52px; font-weight: 820; letter-spacing: -1.6px; }
     .streak-value { fill: #f0f6fc; font-size: 38px; font-weight: 760; letter-spacing: -0.8px; }

--- a/scripts/normalize-profile-stats.mjs
+++ b/scripts/normalize-profile-stats.mjs
@@ -2,7 +2,7 @@ import { writeFile } from "node:fs/promises";
 
 const token = process.env.PROFILE_STATS_TOKEN;
 const username = process.env.PROFILE_STATS_USERNAME ?? "Aaxhirrr";
-const statsPath = "profile/cool-stats.svg";
+const statsPath = "profile/github-stats.svg";
 const displayedGrade = "A++";
 const now = process.env.PROFILE_STATS_NOW
   ? new Date(process.env.PROFILE_STATS_NOW)
@@ -363,7 +363,7 @@ const description = [
   `${streaks.longest.count} day longest streak`,
 ].join(", ");
 
-const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="660" viewBox="0 0 1100 660" role="img" aria-labelledby="titleId descId">
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="660" viewBox="0 0 1100 660" role="img" aria-labelledby="titleId descId" data-theme="stats">
   <title id="titleId">${escapeXml(titleName)}&apos;s Stats, Grade ${displayedGrade}</title>
   <desc id="descId">${escapeXml(description)}</desc>
   <defs>


### PR DESCRIPTION
Renames the section and card to Stats, removes commits and issues, rebuilds the visual hierarchy, and moves the generated SVG to a fresh cache-safe URL.\n\nValidation:\n- node --check scripts/normalize-profile-stats.mjs\n- authenticated generator run\n- xmllint --noout profile/github-stats.svg\n- git diff --check\n- rendered at 1100x660 and README display size